### PR TITLE
Updated ldap address to ipa10-nrh

### DIFF
--- a/CSHUserSig.php
+++ b/CSHUserSig.php
@@ -38,7 +38,7 @@ function parseUserSignatures($parser, $text) {
 
 function getUserInfoFromText($name) {
 	if(!isset($GLOBALS['ldap_ds'])){
-		$GLOBALS['ldap_ds'] = ldap_connect('ldap.csh.rit.edu');
+		$GLOBALS['ldap_ds'] = ldap_connect('ipa10-nrh.csh.rit.edu');
 		ldap_bind($GLOBALS['ldap_ds'],'cn=wiki,ou=Apps,dc=csh,dc=rit,dc=edu','');
 	}
 	$sr = ldap_list($GLOBALS['ldap_ds'],'ou=Users,dc=csh,dc=rit,dc=edu',"(displayName=*$name*)",array('uid','sn','givenname','cn'));
@@ -48,7 +48,7 @@ function getUserInfoFromText($name) {
 }
 function getUserInfoFromUID($name) {
 	if(!isset($GLOBALS['ldap_ds'])){
-		$GLOBALS['ldap_ds'] = ldap_connect('ldap.csh.rit.edu');
+		$GLOBALS['ldap_ds'] = ldap_connect('ipa10-nrh.csh.rit.edu');
 		ldap_bind($GLOBALS['ldap_ds'],'cn=wiki,ou=Apps,dc=csh,dc=rit,dc=edu','');
 	}
 	$sr = ldap_list($GLOBALS['ldap_ds'],'ou=Users,dc=csh,dc=rit,dc=edu',"(uid=$name)",array('uid','sn','givenname','cn'));


### PR DESCRIPTION
Did I do work on the main branch? Yes. Am I sorry? Maybe.

Currently the plugin calls an old address to ldap, this should hopefully resolve that and allow the ^^userID^^ formatting to work on the wiki again.

I don't fully know how our mediawiki instance operates. I'm not sure if it'll just need a simple reboot to start using the new version of the plugin or if something has to be manually done. Let me know if I could help with any of that.